### PR TITLE
Update for JupyterNotebook users.

### DIFF
--- a/pythonCoronaCases.py
+++ b/pythonCoronaCases.py
@@ -49,7 +49,7 @@ async def getCases():
 async def main():
 	cases = await asyncio.gather(getCases())
 
-asyncio.run(main())
+await main()
 
 
 


### PR DESCRIPTION
The first version of this program won't work in Jupyter Notebook as it has a different working for asynchronous programming in its backend. So instead of using asyncio.run(func_name()), we directly call the function preceded by 'await' keyword.